### PR TITLE
Add English documentation for Amazon Q CLI Workshop

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,51 @@
+# Amazon Q CLI Workshop
+
+This repository contains a series of labs designed to help users learn how to use Amazon Q CLI to solve various problems in AWS environments.
+
+## What is Amazon Q CLI?
+
+Amazon Q CLI is a command-line tool that brings the power of Amazon Q to the command-line interface. With Amazon Q CLI, users can:
+
+- Get help and recommendations for AWS services
+- Diagnose and solve issues with AWS resources
+- Generate and interpret AWS CLI commands
+- Receive guidance on AWS best practices
+- Interact with an AI assistant in a conversational manner
+
+## Lab List
+
+This workshop includes the following labs:
+
+1. [EC2 Connectivity Lab](./ec2-connectivity-lab/README.en.md) - Learn how to use Amazon Q CLI to diagnose and solve connectivity issues with EC2 instances.
+2. [AWS Resource Usage Analysis and Cost Optimization Lab](./cost-optimization-lab/README.en.md) - Learn how to use Amazon Q CLI to analyze AWS resource usage and get cost optimization recommendations.
+3. [Automated Operations Lab](./automated-operations-lab/README.en.md) - Learn how to use Amazon Q CLI to assist in developing and deploying automated operations tasks.
+
+## Prerequisites
+
+Before starting the labs, please ensure:
+
+1. AWS CLI is installed and configured
+2. Amazon Q CLI is installed
+3. You have appropriate AWS permissions to create and manage resources used in the labs
+
+### Installing Amazon Q CLI
+
+```bash
+# Install Amazon Q CLI using pip
+pip install amazon-q-cli
+
+# Verify installation
+q --version
+```
+
+## How to Use This Workshop
+
+Each lab is located in a separate directory and includes:
+- README.en.md: Lab instructions and steps in English
+- Supporting files: Such as CloudFormation templates, scripts, etc.
+
+Follow the instructions in the README.en.md file in each lab.
+
+## Contributions
+
+Contributions of new labs or improvements to existing labs are welcome. Please submit a Pull Request or create an Issue.

--- a/automated-operations-lab/README.en.md
+++ b/automated-operations-lab/README.en.md
@@ -1,0 +1,148 @@
+# Automated Operations Lab
+
+This lab will guide you in using Amazon Q CLI to create an automated operations solution that detects EC2 instances that haven't been started for a long time and sends notifications via SNS.
+
+## Lab Overview
+
+In this lab, you will:
+1. Use CloudFormation to deploy a complete solution, including:
+   - Lambda function to check EC2 instance status
+   - Necessary IAM roles and permissions
+   - SNS topic for sending notifications
+   - CloudWatch Events trigger to periodically execute the Lambda function
+2. Use Amazon Q CLI to help understand and modify the solution
+3. Test the functionality of the solution
+
+## Prerequisites
+
+- AWS account
+- AWS CLI installed and configured
+- Amazon Q CLI installed
+- Appropriate permissions to create CloudFormation stacks
+
+## Lab Steps
+
+### Step 1: Review Lab Files
+
+First, review the following files to understand their functions:
+- `lambda_function.py` - Lambda function code for detecting EC2 instances that haven't been started for a long time
+- `template.yaml` - CloudFormation template for creating all necessary resources
+
+### Step 2: Deploy CloudFormation Stack
+
+1. Package the Lambda function code:
+
+```bash
+# Create deployment package
+zip ec2_monitor_function.zip lambda_function.py
+```
+
+2. Create an S3 bucket to store the Lambda code (if you don't already have one):
+
+```bash
+aws s3 mb s3://your-deployment-bucket-name
+```
+
+3. Upload the Lambda code to S3:
+
+```bash
+aws s3 cp ec2_monitor_function.zip s3://your-deployment-bucket-name/
+```
+
+4. Deploy the CloudFormation stack:
+
+```bash
+aws cloudformation create-stack \
+    --stack-name ec2-monitor-stack \
+    --template-body file://template.yaml \
+    --capabilities CAPABILITY_IAM \
+    --parameters \
+        ParameterKey=EmailAddress,ParameterValue=your-email@example.com \
+        ParameterKey=S3BucketName,ParameterValue=your-deployment-bucket-name \
+        ParameterKey=S3Key,ParameterValue=ec2_monitor_function.zip
+```
+
+5. After deployment is complete, you will receive a confirmation email. You need to click the confirmation link to subscribe to the SNS topic.
+
+### Step 3: Use Amazon Q CLI to Understand the Solution
+
+Use Amazon Q CLI to help understand how the solution works:
+
+```bash
+q chat "Explain how the code in lambda_function.py detects EC2 instances that haven't been started for a long time?"
+```
+
+```bash
+q chat "How are the IAM permissions configured in the CloudFormation template, and why are these permissions needed?"
+```
+
+### Step 4: Use Amazon Q CLI to Modify the Solution
+
+Suppose you want to modify the solution, such as changing the detection threshold or adding more filtering conditions. You can use Amazon Q CLI for help:
+
+```bash
+q chat "How can I modify the Lambda function code to change the threshold from 30 days to 45 days?"
+```
+
+```bash
+q chat "How can I add additional filtering conditions to the Lambda function to only check EC2 instances with specific tags?"
+```
+
+### Step 5: Test the Solution
+
+1. Manually invoke the Lambda function to test its functionality:
+
+```bash
+# Get the Lambda function name
+LAMBDA_NAME=$(aws cloudformation describe-stacks --stack-name ec2-monitor-stack --query "Stacks[0].Outputs[?OutputKey=='LambdaFunctionName'].OutputValue" --output text)
+
+# Invoke the Lambda function
+aws lambda invoke --function-name $LAMBDA_NAME output.txt
+```
+
+2. Check CloudWatch Logs to verify the function execution:
+
+```bash
+# View recent logs
+aws logs get-log-events --log-group-name /aws/lambda/$LAMBDA_NAME --log-stream-name $(aws logs describe-log-streams --log-group-name /aws/lambda/$LAMBDA_NAME --order-by LastEventTime --descending --limit 1 --query 'logStreams[0].logStreamName' --output text)
+```
+
+### Step 6: Use Amazon Q CLI for Troubleshooting
+
+If you encounter issues during testing, you can use Amazon Q CLI for help:
+
+```bash
+q chat "My Lambda function execution failed, CloudWatch logs show error: <error message>. How can I resolve this issue?"
+```
+
+```bash
+q chat "I'm not receiving SNS notifications. How can I check if the SNS configuration is correct?"
+```
+
+## Clean Up Resources
+
+After completing the lab, use the following commands to delete all created resources:
+
+1. Delete the CloudFormation stack:
+
+```bash
+aws cloudformation delete-stack --stack-name ec2-monitor-stack
+```
+
+2. Delete the Lambda deployment package from the S3 bucket:
+
+```bash
+aws s3 rm s3://your-deployment-bucket-name/ec2_monitor_function.zip
+```
+
+3. If you created an S3 bucket specifically for this lab, you can also choose to delete it:
+
+```bash
+# Make sure the bucket is empty
+aws s3 rm s3://your-deployment-bucket-name --recursive
+
+# Delete the bucket
+aws s3 rb s3://your-deployment-bucket-name
+```
+
+This will delete all resources created for this lab, including the Lambda function, IAM roles, SNS topic, CloudWatch Events rule, and deployment files in S3.

--- a/cost-optimization-lab/README.en.md
+++ b/cost-optimization-lab/README.en.md
@@ -1,0 +1,99 @@
+# AWS Resource Usage Analysis and Cost Optimization Lab
+
+This lab will guide you on how to use Amazon Q CLI to analyze AWS resource usage, get cost optimization recommendations, and implement optimization measures.
+
+## Lab Objectives
+
+Through this lab, you will learn how to:
+- Use Amazon Q CLI to query AWS resource usage
+- Analyze resource utilization and cost data
+- Get targeted cost optimization recommendations
+- Implement recommended optimization measures
+- Evaluate cost savings after optimization
+
+## Prerequisites
+
+1. AWS CLI installed and configured
+2. Amazon Q CLI installed
+3. Permissions to view AWS Cost Explorer and AWS resources
+4. At least one month of AWS usage history
+
+## Lab Steps
+
+### Step 1: Query Resource Usage
+
+Use Amazon Q CLI to query your AWS resource usage:
+
+```bash
+q chat
+```
+
+In the conversation, you can ask questions like:
+- "Query my EC2 instance usage from last month"
+- "Analyze my S3 storage usage trends"
+- "Show the most expensive services in my account"
+- "View my RDS instance utilization"
+
+### Step 2: Get Cost Optimization Recommendations
+
+Continue the conversation with Amazon Q to get cost optimization recommendations:
+
+```bash
+# Continue in the same conversation
+```
+
+You can ask:
+- "Which EC2 instances can be resized to save costs?"
+- "Identify idle or underutilized resources"
+- "Recommend resources that can use Savings Plans or Reserved Instances"
+- "Analyze my EBS volume usage and provide optimization recommendations"
+
+### Step 3: Implement Optimization Measures
+
+Based on Amazon Q's recommendations, implement optimization measures. For example:
+
+1. Resize EC2 instances:
+```bash
+aws ec2 stop-instances --instance-ids i-1234567890abcdef0
+aws ec2 modify-instance-attribute --instance-id i-1234567890abcdef0 --instance-type t3.micro
+aws ec2 start-instances --instance-ids i-1234567890abcdef0
+```
+
+2. Delete unused resources:
+```bash
+aws ec2 terminate-instances --instance-ids i-1234567890abcdef0
+```
+
+3. Set lifecycle policies:
+```bash
+aws s3api put-bucket-lifecycle-configuration --bucket my-bucket --lifecycle-configuration file://lifecycle-config.json
+```
+
+### Step 4: Evaluate Optimization Effects
+
+After implementing optimization measures, use Amazon Q CLI to evaluate the effects:
+
+```bash
+q chat
+```
+
+You can ask:
+- "Compare costs before and after optimization"
+- "Predict next month's AWS bill"
+- "Analyze the impact of optimization measures"
+
+## Lab Extensions
+
+1. Create automation scripts to regularly perform resource optimization
+2. Set up cost budgets and alerts
+3. Explore using AWS Organizations and SCPs to implement cost control policies
+
+## Summary
+
+Through this lab, you learned how to use Amazon Q CLI to analyze AWS resource usage, get cost optimization recommendations, and implement optimization measures. These skills can help you continuously optimize your AWS environment, reduce costs, and improve resource utilization.
+
+## Reference Resources
+
+- [AWS Cost Explorer Documentation](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-what-is.html)
+- [AWS Cost Optimization Best Practices](https://aws.amazon.com/aws-cost-management/aws-cost-optimization/)
+- [Amazon Q CLI Documentation](https://docs.aws.amazon.com/amazonq/latest/cli-user-guide/what-is.html)

--- a/ec2-connectivity-lab/README.en.md
+++ b/ec2-connectivity-lab/README.en.md
@@ -1,0 +1,86 @@
+# EC2 Connectivity Lab
+
+## Lab Overview
+
+In this lab, you will learn how to use Amazon Q CLI to diagnose and solve connectivity issues with EC2 instances. The lab simulates a common scenario: an EC2 instance has been deployed, but due to security group configurations and network ACL restrictions, you cannot connect to the instance via SSH.
+
+## Lab Steps
+
+### 1. Deploy Resources
+
+Use the provided CloudFormation template to deploy lab resources:
+```bash
+aws cloudformation deploy --template-file template.yaml --stack-name ec2-connectivity-lab --capabilities CAPABILITY_IAM
+```
+
+After deployment is complete, get the public IP address of the EC2 instance:
+```bash
+aws cloudformation describe-stacks --stack-name ec2-connectivity-lab --query "Stacks[0].Outputs[?OutputKey=='PublicIP'].OutputValue" --output text
+```
+
+### 2. Verify HTTP Connection
+
+First, access the EC2 instance via HTTP to confirm that the instance is running and the public IP is reachable:
+```bash
+# Use curl command to verify HTTP connection
+curl http://<EC2-instance-public-IP>
+
+# Or visit in a browser
+# http://<EC2-instance-public-IP>
+```
+
+You should see a simple HTML page displaying "EC2 Connectivity Lab" and a successful connection message. This indicates that the EC2 instance is running normally and the HTTP port (80) is open.
+
+### 3. Try SSH Connection
+
+Next, try to connect to the EC2 instance using SSH:
+```bash
+ssh ec2-user@<EC2-instance-public-IP>
+```
+
+You will find that you cannot connect to the instance via SSH due to security group and network ACL restrictions.
+
+### 4. Use Amazon Q CLI to Diagnose the Problem
+
+Use Amazon Q CLI to diagnose the connection issue:
+```bash
+q chat
+```
+
+In the chat, describe the problem you're experiencing, for example:
+"I cannot SSH connect to my EC2 instance. Please help me diagnose the problem and provide a solution."
+
+### 5. Solve the Problem
+
+Following Amazon Q CLI's recommendations, solve the following issues:
+- Security group configuration issue: Add rules to allow SSH access
+- Network ACL restrictions: Modify network ACLs to allow necessary inbound and outbound traffic
+
+### 6. Verify Connection
+
+After completing the above steps, try to connect to the EC2 instance via SSH again to verify that the problem has been resolved:
+```bash
+ssh ec2-user@<EC2-instance-public-IP>
+```
+
+### 7. Resource Cleanup
+
+After completing the lab, clean up all resources to avoid unnecessary charges:
+```bash
+# Delete CloudFormation stack
+aws cloudformation delete-stack --stack-name ec2-connectivity-lab
+
+# Verify the stack has been deleted
+aws cloudformation describe-stacks --stack-name ec2-connectivity-lab
+```
+
+If the last command returns an error "Stack with id ec2-connectivity-lab does not exist", it indicates that the resources have been successfully cleaned up.
+
+## Lab Summary
+
+Through this lab, you will learn:
+- How to use Amazon Q CLI to diagnose EC2 connectivity issues
+- How to identify and resolve security group configuration issues
+- How to identify and resolve network ACL restrictions
+- How to verify if connection issues have been resolved
+- How to properly clean up AWS resources


### PR DESCRIPTION
- Add main README.en.md with English workshop overview and instructions
- Add English versions of lab documentation:
  - EC2 connectivity lab instructions (ec2-connectivity-lab/README.en.md)
  - Cost optimization lab instructions (cost-optimization-lab/README.en.md)
  - Automated operations lab instructions (automated-operations-lab/README.en.md)

These additions make the workshop accessible to English-speaking users while maintaining the original Chinese documentation. All lab instructions have been translated with equivalent content, including setup steps, commands, and explanations.